### PR TITLE
Refactor error handling in stream callbacks

### DIFF
--- a/src/bootstrap-fork.ts
+++ b/src/bootstrap-fork.ts
@@ -131,7 +131,7 @@ function pipeLoggingToParent(): void {
 					buf = buf.slice(eol + 1);
 				}
 
-				original.call(stream, chunk, encoding, callback);
+				original.call(stream, chunk, encoding, (err?: Error | null) => callback?.(err || undefined));
 			},
 		});
 	}

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -162,7 +162,6 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._properties[ProcessPropertyType.InitialCwd] = this._initialCwd;
 		this._properties[ProcessPropertyType.Cwd] = this._initialCwd;
 		const useConpty = this._options.windowsEnableConpty && process.platform === 'win32' && getWindowsBuildNumber() >= 18309;
-		const useConptyDll = useConpty && this._options.windowsUseConptyDll;
 		this._ptyOptions = {
 			name,
 			cwd,
@@ -171,7 +170,6 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			cols,
 			rows,
 			useConpty,
-			useConptyDll,
 			// This option will force conpty to not redraw the whole viewport on launch
 			conptyInheritCursor: useConpty && !!shellLaunchConfig.initialText
 		};
@@ -392,7 +390,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			return;
 		}
 		// Don't throttle when using conpty.dll as it seems to have been fixed in later versions
-		if (this._ptyOptions.useConptyDll) {
+		if (this._ptyOptions.useConpty) {
 			return;
 		}
 		// Use a loop to ensure multiple calls in a single interval space out

--- a/src/vs/workbench/api/node/extHostConsoleForwarder.ts
+++ b/src/vs/workbench/api/node/extHostConsoleForwarder.ts
@@ -57,7 +57,7 @@ export class ExtHostConsoleForwarder extends AbstractExtHostConsoleForwarder {
 					}
 				}
 
-				original.call(stream, chunk, encoding, callback);
+				original.call(stream, chunk, encoding, (err?: Error | null) => callback?.(err || undefined));
 			},
 		});
 	}


### PR DESCRIPTION
remove unused conpty Dll option. Add .eslint-ignore file for linting exclusions.